### PR TITLE
HAP-583 - Git polling shows exception when job is currently running

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.0</version>
+            <version>2.5</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </parent>
 
     <artifactId>artifactory</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Artifactory Plugin</name>
     <description>Integrates Artifactory to Jenkins</description>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <buildinfo.version>2.5.0</buildinfo.version>
         <buildinfo.maven3.version>2.5.0</buildinfo.maven3.version>
         <buildinfo.gradle.version>3.1.0</buildinfo.gradle.version>
-        <buildinfo.ivy.version>2.5.0</buildinfo.ivy.version>
+        <buildinfo.ivy.version>2.5.x-SNAPSHOT</buildinfo.ivy.version>
         <maven-release-plugin.version>2.2</maven-release-plugin.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <buildinfo.version>2.5.x-SNAPSHOT</buildinfo.version>
         <buildinfo.maven3.version>2.5.0</buildinfo.maven3.version>
-        <buildinfo.gradle.version>3.1.0</buildinfo.gradle.version>
+        <buildinfo.gradle.version>3.1.1</buildinfo.gradle.version>
         <buildinfo.ivy.version>2.5.x-SNAPSHOT</buildinfo.ivy.version>
         <maven-release-plugin.version>2.2</maven-release-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.0</version>
+            <version>2.3.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Artifactory+Plugin</url>
 
     <properties>
-        <buildinfo.version>2.5.0</buildinfo.version>
+        <buildinfo.version>2.5.x-SNAPSHOT</buildinfo.version>
         <buildinfo.maven3.version>2.5.0</buildinfo.maven3.version>
         <buildinfo.gradle.version>3.1.0</buildinfo.gradle.version>
         <buildinfo.ivy.version>2.5.x-SNAPSHOT</buildinfo.ivy.version>

--- a/src/main/java/org/jfrog/hudson/MavenDependency.java
+++ b/src/main/java/org/jfrog/hudson/MavenDependency.java
@@ -16,6 +16,8 @@
 
 package org.jfrog.hudson;
 
+import org.apache.maven.artifact.Artifact;
+
 import java.io.Serializable;
 
 /**
@@ -24,14 +26,25 @@ import java.io.Serializable;
  * @author Yossi Shaul
  */
 public class MavenDependency implements Serializable {
-    public String id;
-    public String groupId;
-    public String artifactId;
-    public String version;
-    public String type;
-    public String classifier;
-    public String scope;
-    public String fileName;
+    private String id;
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private String type;
+    private String classifier;
+    private String scope;
+    private String fileName;
+
+    public MavenDependency(Artifact artifact) {
+        id = artifact.getId() != null ? artifact.getId().intern() : null;
+        groupId = artifact.getGroupId() != null ? artifact.getGroupId().intern() : null;
+        artifactId = artifact.getArtifactId() != null ? artifact.getArtifactId().intern() : null;
+        version = artifact.getVersion() != null ? artifact.getVersion().intern() : null;
+        classifier = artifact.getClassifier() != null ? artifact.getClassifier().intern() : null;
+        scope = artifact.getScope() != null ? artifact.getScope().intern() : null;
+        fileName = artifact.getFile() != null ? artifact.getFile().getName().intern() : null;
+        type = artifact.getType() != null ? artifact.getType().intern() : null;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -54,5 +67,69 @@ public class MavenDependency implements Serializable {
     @Override
     public int hashCode() {
         return id.hashCode();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getClassifier() {
+        return classifier;
+    }
+
+    public void setClassifier(String classifier) {
+        this.classifier = classifier;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
     }
 }

--- a/src/main/java/org/jfrog/hudson/MavenDependency.java
+++ b/src/main/java/org/jfrog/hudson/MavenDependency.java
@@ -31,7 +31,6 @@ public class MavenDependency implements Serializable {
     private String artifactId;
     private String version;
     private String type;
-    private String classifier;
     private String scope;
     private String fileName;
 
@@ -40,7 +39,6 @@ public class MavenDependency implements Serializable {
         groupId = artifact.getGroupId() != null ? artifact.getGroupId().intern() : null;
         artifactId = artifact.getArtifactId() != null ? artifact.getArtifactId().intern() : null;
         version = artifact.getVersion() != null ? artifact.getVersion().intern() : null;
-        classifier = artifact.getClassifier() != null ? artifact.getClassifier().intern() : null;
         scope = artifact.getScope() != null ? artifact.getScope().intern() : null;
         fileName = artifact.getFile() != null ? artifact.getFile().getName().intern() : null;
         type = artifact.getType() != null ? artifact.getType().intern() : null;
@@ -109,27 +107,11 @@ public class MavenDependency implements Serializable {
         this.type = type;
     }
 
-    public String getClassifier() {
-        return classifier;
-    }
-
-    public void setClassifier(String classifier) {
-        this.classifier = classifier;
-    }
-
     public String getScope() {
         return scope;
     }
 
-    public void setScope(String scope) {
-        this.scope = scope;
-    }
-
     public String getFileName() {
         return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
     }
 }

--- a/src/main/java/org/jfrog/hudson/ServerDetails.java
+++ b/src/main/java/org/jfrog/hudson/ServerDetails.java
@@ -138,7 +138,10 @@ public class ServerDetails {
     }
 
     public String getDeployReleaseRepositoryKey() {
-        return getDeployReleaseRepository().getRepoKey();
+        if (deployReleaseRepository != null){
+            return deployReleaseRepository.getRepoKey();
+        }
+        return StringUtils.EMPTY;
     }
 
     public String getDeploySnapshotRepositoryKey() {

--- a/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
@@ -492,6 +492,12 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
                 ServerDetails serverDetails = getDetails();
                 ReleaseAction releaseAction = ActionableHelper.getLatestAction(build, ReleaseAction.class);
                 if (releaseAction != null) {
+                    if (releaseAction.getTagUrl() != null) {
+                        env.put("RELEASE_SCM_TAG", releaseAction.getTagUrl());
+                    }
+                    if (releaseAction.getReleaseBranch() != null) {
+                        env.put("RELEASE_SCM_BRANCH", releaseAction.getReleaseBranch());
+                    }
                     String stagingRepository = releaseAction.getStagingRepositoryKey();
                     if (StringUtils.isBlank(stagingRepository)) {
                         stagingRepository = getRepositoryKey();

--- a/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
@@ -492,12 +492,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
                 ServerDetails serverDetails = getDetails();
                 ReleaseAction releaseAction = ActionableHelper.getLatestAction(build, ReleaseAction.class);
                 if (releaseAction != null) {
-                    if (releaseAction.getTagUrl() != null) {
-                        env.put("RELEASE_SCM_TAG", releaseAction.getTagUrl());
-                    }
-                    if (releaseAction.getReleaseBranch() != null) {
-                        env.put("RELEASE_SCM_BRANCH", releaseAction.getReleaseBranch());
-                    }
+                    releaseAction.addVars(env);
                     String stagingRepository = releaseAction.getStagingRepositoryKey();
                     if (StringUtils.isBlank(stagingRepository)) {
                         stagingRepository = getRepositoryKey();

--- a/src/main/java/org/jfrog/hudson/maven2/MavenBuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/maven2/MavenBuildInfoDeployer.java
@@ -106,10 +106,10 @@ public class MavenBuildInfoDeployer extends AbstractBuildInfoDeployer {
             Set<MavenDependency> dependencies = dependenciesRecord.getDependencies();
             for (MavenDependency dependency : dependencies) {
                 DependencyBuilder dependencyBuilder = new DependencyBuilder()
-                        .id(dependency.id)
-                        .scopes(Sets.newHashSet(dependency.scope))
-                        .type(dependency.type)
-                        .md5(getMd5(dependency.groupId, dependency.fileName, mavenBuild));
+                        .id(dependency.getId())
+                        .scopes(Sets.newHashSet(dependency.getScope()))
+                        .type(dependency.getType())
+                        .md5(getMd5(dependency.getGroupId(), dependency.getFileName(), mavenBuild));
                 moduleBuilder.addDependency(dependencyBuilder.build());
             }
             // delete them once used

--- a/src/main/java/org/jfrog/hudson/maven2/MavenDependenciesRecorder.java
+++ b/src/main/java/org/jfrog/hudson/maven2/MavenDependenciesRecorder.java
@@ -90,16 +90,7 @@ public class MavenDependenciesRecorder extends MavenReporter {
         if (artifacts != null) {
             for (Artifact dependency : artifacts) {
                 if (dependency.isResolved() && dependency.getFile() != null) {
-                    MavenDependency mavenDependency = new MavenDependency();
-                    mavenDependency.id = dependency.getId();
-                    mavenDependency.groupId = dependency.getGroupId();
-                    mavenDependency.artifactId = dependency.getArtifactId();
-                    mavenDependency.version = dependency.getVersion();
-                    mavenDependency.classifier = dependency.getClassifier();
-                    mavenDependency.scope = dependency.getScope();
-                    mavenDependency.fileName = dependency.getFile().getName();
-                    mavenDependency.type = dependency.getType();
-                    dependencies.add(mavenDependency);
+                    dependencies.add(new MavenDependency(dependency));
                 }
             }
         }

--- a/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
+++ b/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
@@ -111,6 +111,11 @@ public class MavenExtractorEnvironment extends Environment {
         env.put(ExtractorUtils.EXTRACTOR_USED, "true");
 
         if (!initialized) {
+            ReleaseAction release = ActionableHelper.getLatestAction(build, ReleaseAction.class);
+            if (release != null) {
+                release.addVars(env);
+            }
+
             try {
                 PublisherContext publisherContext = null;
                 if (publisher != null) {

--- a/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
+++ b/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
@@ -109,13 +109,12 @@ public class MavenExtractorEnvironment extends Environment {
         }
 
         env.put(ExtractorUtils.EXTRACTOR_USED, "true");
+        ReleaseAction release = ActionableHelper.getLatestAction(build, ReleaseAction.class);
+        if (release != null) {
+            release.addVars(env);
+        }
 
         if (!initialized) {
-            ReleaseAction release = ActionableHelper.getLatestAction(build, ReleaseAction.class);
-            if (release != null) {
-                release.addVars(env);
-            }
-
             try {
                 PublisherContext publisherContext = null;
                 if (publisher != null) {

--- a/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
+++ b/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
@@ -607,4 +607,16 @@ public abstract class ReleaseAction<P extends AbstractProject & BuildableItem,
             return displayMessage;
         }
     }
+
+    /**
+     * Add some of the release build properties to a map.
+     */
+    public void addVars(Map<String, String> env) {
+        if (tagUrl != null) {
+            env.put("RELEASE_SCM_TAG", tagUrl);
+        }
+        if (releaseBranch != null) {
+            env.put("RELEASE_SCM_BRANCH", releaseBranch);
+        }
+    }
 }

--- a/src/main/java/org/jfrog/hudson/release/scm/ScmCoordinator.java
+++ b/src/main/java/org/jfrog/hudson/release/scm/ScmCoordinator.java
@@ -46,7 +46,7 @@ public interface ScmCoordinator {
     /**
      * Called after a successful release build.
      */
-    void afterSuccessfulReleaseVersionBuild() throws InterruptedException, IOException;
+    void afterSuccessfulReleaseVersionBuild() throws Exception;
 
     /**
      * Called before changing to next development version.
@@ -63,7 +63,7 @@ public interface ScmCoordinator {
     /**
      * Called after the build has completed and the result was finalized.
      */
-    void buildCompleted() throws IOException, InterruptedException;
+    void buildCompleted() throws Exception;
 
     /**
      * Called before a file is modified.

--- a/src/main/java/org/jfrog/hudson/release/scm/git/GitCoordinator.java
+++ b/src/main/java/org/jfrog/hudson/release/scm/git/GitCoordinator.java
@@ -71,7 +71,7 @@ public class GitCoordinator extends AbstractScmCoordinator {
         }
     }
 
-    public void afterSuccessfulReleaseVersionBuild() throws InterruptedException, IOException {
+    public void afterSuccessfulReleaseVersionBuild() throws Exception {
         if (modifiedFilesForReleaseVersion) {
             // commit local changes
             log(String.format("Committing release version on branch '%s'", state.currentWorkingBranch));
@@ -88,12 +88,6 @@ public class GitCoordinator extends AbstractScmCoordinator {
             // push the current branch
             scmManager.push(scmManager.getRemoteConfig(releaseAction.getTargetRemoteName()), state.currentWorkingBranch);
             state.releaseBranchPushed = true;
-        }
-
-        if (releaseAction.isCreateVcsTag()) {
-            // push the tag
-            scmManager.pushTag(scmManager.getRemoteConfig(releaseAction.getTargetRemoteName()), releaseAction.getTagUrl());
-            state.tagPushed = true;
         }
     }
 
@@ -114,7 +108,7 @@ public class GitCoordinator extends AbstractScmCoordinator {
         }
     }
 
-    public void buildCompleted() throws IOException, InterruptedException {
+    public void buildCompleted() throws Exception {
         if (build.getResult().isBetterOrEqualTo(Result.SUCCESS)) {
             // pull before attempting to push changes?
             //scmManager.pull(scmManager.getRemoteUrl(), checkoutBranch);
@@ -134,9 +128,6 @@ public class GitCoordinator extends AbstractScmCoordinator {
             }
             if (state.tagCreated) {
                 safeDeleteTag(releaseAction.getTagUrl());
-            }
-            if (state.tagPushed) {
-                safeDeleteRemoteTag(scmManager.getRemoteConfig(releaseAction.getTargetRemoteName()), releaseAction.getTagUrl());
             }
             // reset changes done on the original checkout branch (next dev version)
             safeRevertWorkingCopy();
@@ -170,15 +161,6 @@ public class GitCoordinator extends AbstractScmCoordinator {
         }
     }
 
-    private void safeDeleteRemoteTag(ReleaseRepository remoteRepository, String tag) {
-        try {
-            scmManager.deleteRemoteTag(remoteRepository, tag);
-        } catch (Exception e) {
-            debuggingLogger.log(Level.FINE, "Failed to delete remote tag: ", e);
-            log("Failed to delete remote tag: " + e.getLocalizedMessage());
-        }
-    }
-
     private void safeRevertWorkingCopy() {
         try {
             scmManager.revertWorkingCopy();
@@ -197,6 +179,5 @@ public class GitCoordinator extends AbstractScmCoordinator {
         boolean releaseBranchCreated;
         boolean releaseBranchPushed;
         boolean tagCreated;
-        boolean tagPushed;
     }
 }

--- a/src/main/java/org/jfrog/hudson/release/scm/git/GitManager.java
+++ b/src/main/java/org/jfrog/hudson/release/scm/git/GitManager.java
@@ -82,19 +82,12 @@ public class GitManager extends AbstractScmManager<GitSCM> {
         client.tag(tagName, commitMessage);
     }
 
-    public void push(final ReleaseRepository releaseRepository, final String branch) throws IOException, InterruptedException {
+    public void push(final ReleaseRepository releaseRepository, final String branch) throws Exception {
         GitClient client = getGitClient(releaseRepository);
 
         log(buildListener, String.format("Pushing branch '%s' to '%s'", branch, releaseRepository.getGitUri()));
-        client.push(releaseRepository.getRepositoryName(), "refs/heads/" + branch);
-    }
-
-    public void pushTag(final ReleaseRepository releaseRepository, final String tagName) throws IOException, InterruptedException {
-        GitClient client = getGitClient(releaseRepository);
-
-        String escapedTagName = tagName.replace(' ', '_');
-        log(buildListener, String.format("Pushing tag '%s' to '%s'", escapedTagName, releaseRepository.getGitUri()));
-        client.push(releaseRepository.getRepositoryName(), "refs/tags/" + escapedTagName);
+        client.push().tags(true).to(new URIish(releaseRepository.getTargetRepoPrivateUri()))
+            .ref("refs/heads/" + branch).timeout(10).execute();
     }
 
     public void revertWorkingCopy() throws IOException, InterruptedException {

--- a/src/main/webapp/help/BintrayPublishAction/help-licenses.html
+++ b/src/main/webapp/help/BintrayPublishAction/help-licenses.html
@@ -1,4 +1,4 @@
 <div>
-    Comma separated list of valid licenses.<br>
-    For example: BSD, MIT, Apache-2.0
+    Comma separated list of valid licenses. For example: BSD, MIT, Apache-2.0<br>
+    This field is mandatory in case of OSS Bintray package.
 </div>

--- a/src/main/webapp/help/BintrayPublishAction/help-repository.html
+++ b/src/main/webapp/help/BintrayPublishAction/help-repository.html
@@ -1,3 +1,3 @@
 <div>
-    A target repository in Bintray
+    A target repository in Bintray.
 </div>

--- a/src/main/webapp/help/BintrayPublishAction/help-subject.html
+++ b/src/main/webapp/help/BintrayPublishAction/help-subject.html
@@ -1,3 +1,3 @@
 <div>
-    Subject in Bintray
+    Subject in Bintray.
 </div>

--- a/src/main/webapp/help/BintrayPublishAction/help-vcsUrl.html
+++ b/src/main/webapp/help/BintrayPublishAction/help-vcsUrl.html
@@ -1,3 +1,4 @@
 <div>
-    Please enter a valid Version Control URL.<br>This is not mandatory if you are a Premium Bintray user.
+    Please enter a valid Version Control URL.<br>
+    This field is mandatory in case of OSS Bintray repository.
 </div>

--- a/src/main/webapp/help/BintrayPublishAction/help-version.html
+++ b/src/main/webapp/help/BintrayPublishAction/help-version.html
@@ -1,3 +1,3 @@
 <div>
-    A target version under the package.If the version does not yet exist in Bintray, it is created automatically
+    A target version under the package. If the version does not yet exist in Bintray, it is created automatically.
 </div>


### PR DESCRIPTION
Few more words about this issue and my fix
Jenkins : 1.617 with multiple nodes, Linux env
Gerrit Trigger Jenkins plugin: 2.14.0
Artifactory Jenkins plugin: 2.3.0
Jenkins job is Maven project with Gerrit Trigger and Post Build Action to Deploy artifacts Artifactory
Exception generated in system log and does not touch build result, when Gerrit plugin generates successful notification to Gerrit on the very last step of the build.
At this time global Computer.currentComputer() is null in Artifactory getMavenInstallation call. More correct way is to use build.getBuiltOn().toComputer() call to get this object.
I have tested the return value of Computer.currentComputer() and build.getBuiltOn().toComputer() during build life cycle. All time these values were identical, except the very last step, when Gerrit plugin sends final notification. My build.getBuiltOn().toComputer()  solution returns proper value , when original Computer.currentComputer() call returns null (visible in system Jenkins log only).

Fix is provided in forked jenkins-artifactory-plugin branch HAP-583 (branched from 2.3.0 release commit) : https://github.com/4public/jenkins-artifactory-plugin/tree/HAP-583
Only one file was modified: src/main/java/org/jfrog/hudson/util/MavenVersionHelper.java
